### PR TITLE
Refactor common/read_job_flags.envsh out of terraform/run_v1.0.sh

### DIFF
--- a/common/git_checkout_efficient.sh
+++ b/common/git_checkout_efficient.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Exit on error
+set -e
+
+# Check whether the required vars are set
+: ${1?'First argument missing - should be the directory to checkout in'}
+: ${2?'Second argument missing - should be the repository URL to checkout'}
+: ${3?'Third argument missing - should be the git commit/branch/tag to checkout'}
+
+SPARSE_CHECKOUT_REQUESTED=false
+[[ -n "${4}" ]] && SPARSE_CHECKOUT_REQUESTED=true
+GIT_DIR="${1}"
+GIT_URL="${2}"
+GIT_CHECKOUT_COMMITISH="${3}"
+
+# Process flags specified
+echo "# Checking out '${2}' (${3}) in directory: ${1}"
+[[ "${SPARSE_CHECKOUT_REQUESTED}" == 'true' ]] && echo "# Sparse checkout using path(s): ${@:4}" || true
+# Checkout QA source repository efficiently
+git init --initial-branch=main "${GIT_DIR}"
+[[ "${SPARSE_CHECKOUT_REQUESTED}" == 'true' ]] && git --work-tree="${GIT_DIR}" --git-dir="${GIT_DIR}"/.git/ sparse-checkout set --no-cone || true
+git --work-tree="${GIT_DIR}" --git-dir="${GIT_DIR}"/.git/ remote add origin "${GIT_URL}"
+git --work-tree="${GIT_DIR}" --git-dir="${GIT_DIR}"/.git/ fetch --filter=blob:none --depth 1 origin "${GIT_CHECKOUT_COMMITISH}"
+git --work-tree="${GIT_DIR}" --git-dir="${GIT_DIR}"/.git/ switch --detach FETCH_HEAD
+[[ "${SPARSE_CHECKOUT_REQUESTED}" == 'true' ]] && git --work-tree="${GIT_DIR}" --git-dir="${GIT_DIR}"/.git/ sparse-checkout set --no-cone "${@:4}" || true

--- a/common/read_job_flags.envsh
+++ b/common/read_job_flags.envsh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+TEMP_FLAGS_RESOURCES_DIR=$(mktemp -d)
+"${CICD_SCRIPTS_DIR}"/common/git_checkout_efficient.sh "${TEMP_FLAGS_RESOURCES_DIR}" git@github.com:aerius/flags.git main
+
+function read_job_flags_cleanup() {
+  echo '# Cleaning up flags directory'
+  rm -rf "${TEMP_FLAGS_RESOURCES_DIR}"
+  unset -f read_job_flags_cleanup
+}
+
+# If array doesn't exist yet, create it
+if [[ -z "${FLAG_SETTINGS+x}" ]]; then
+    declare -A FLAG_SETTINGS
+fi
+
+# Process flags specified
+echo '# Reading in flags (if any)'
+for FLAG in $(echo "${FLAGS}" | tr ',' '\n'); do
+  # ignore empty flags
+  if [[ -z "${FLAG}" ]]; then
+    continue
+  fi
+
+  echo '# Processing flag: '"${FLAG}"
+  FLAG_PATH=
+  if [[ -f "${TEMP_FLAGS_RESOURCES_DIR}/${FLAG}.envsh" ]]; then
+    FLAG_PATH="${TEMP_FLAGS_RESOURCES_DIR}/${FLAG}.envsh"
+
+    echo '- Found as global flag.. Reading in..'
+  fi
+  if [[ -f "${TEMP_FLAGS_RESOURCES_DIR}/${PRODUCT_NAME}/${FLAG}.envsh" ]]; then
+    FLAG_PATH="${TEMP_FLAGS_RESOURCES_DIR}/${PRODUCT_NAME}/${FLAG}.envsh"
+
+    echo '- Found as product specific flag.. Reading in..'
+  fi
+
+  if [[ -z "${FLAG_PATH}" ]]; then
+    echo '# Could not find flag '"${FLAG}"'. Crashing hard..'
+    read_job_flags_cleanup
+    exit 1
+  fi
+
+  # Read in
+  source "${FLAG_PATH}"
+done
+
+# Cleaning up flags
+read_job_flags_cleanup

--- a/job/notify_mattermost_message.sh
+++ b/job/notify_mattermost_message.sh
@@ -4,7 +4,7 @@
 set -e
 
 function notify_mattermost_message_add_label() {
-  echo '![label_'"${1}"'](https://nexus.aerius.nl/repository/resources/images/label_'"${1}"'.png)'
+  echo '!['"${1}"'](https://nexus.aerius.nl/repository/resources/images/label_'"${1}"'.png)'
 }
 
 MSG_TITLE="[${BUILD_DISPLAY_NAME^^}](${BUILD_URL})"

--- a/terraform/run_v1.0.sh
+++ b/terraform/run_v1.0.sh
@@ -176,32 +176,7 @@ if [[ -d "${PRODUCT_SPECIFIC_DYNAMIC_SCRIPT_DIR}" ]]; then
 fi
 
 # Process flags specified
-for FLAG in $(echo "${FLAGS}" | tr ',' '\n'); do
-  # ignore empty flags
-  if [[ -z "${FLAG}" ]]; then
-    continue
-  fi
-
-  echo '# Processing flag: '"${FLAG}"
-  FLAG_PATH=
-  if [[ -f "${FLAGS_DIRECTORY}/${FLAG}.envsh" ]]; then
-    FLAG_PATH="${FLAGS_DIRECTORY}/${FLAG}.envsh"
-
-    echo '- Found as global flag.. Reading in..'
-    source "${FLAG_PATH}"
-  fi
-  if [[ -f "${FLAGS_DIRECTORY}/${PRODUCT_NAME}/${FLAG}.envsh" ]]; then
-    FLAG_PATH="${FLAGS_DIRECTORY}/${PRODUCT_NAME}/${FLAG}.envsh"
-
-    echo '- Found as product specific flag.. Reading in..'
-    source "${FLAG_PATH}"
-  fi
-
-  if [[ -z "${FLAG_PATH}" ]]; then
-    echo '# Could not find flag '"${FLAG}"'. Crashing hard..'
-    exit 1
-  fi
-done
+source "${SCRIPT_DIR}"/../common/read_job_flags.envsh
 
 # Write flag settings to environment.terragrunt.hcl
 echo '  # Adding flag settings (if any)' >> "${ENV_ROOT_DIR}/environment.terragrunt.hcl"


### PR DESCRIPTION
This can be re-used by other projects and will checkout the flags from a repository when needed instead of expecting it to be there.
- Added common/git_checkout_efficient.sh This will do a git checkout and supports only pulling latest changes and/or specific directories/files instead of everything.
- Update job/notify_mattermost_message.sh to have cleaner names for the labels This will make it look better in desktop notifications.