### PR TITLE
[job/notify_mattermost_message] Add job post hook URL support for QA jobs

### DIFF
--- a/job/notify_mattermost_message.sh
+++ b/job/notify_mattermost_message.sh
@@ -89,3 +89,14 @@ fi
 echo -n "${MSG_TITLE} ${MSG_ICONS}
 ${MSG_JOB_MESSAGES}
 ${MSG_FOOTER}"
+
+# If QA job and we have a post hook URL, do let them know.
+# We do that here, that for whatever reason output is included from this part,
+#  it will be appended to the end instead of breaking the title
+if [[ "${JOB_NAME}" == 'QA-'* ]] && [[ -n "${CICD_SCRIPTS_JOB_POST_HOOK_URL}" ]]; then
+  curl \
+    -H 'Content-Type: application/json' \
+    --request POST \
+    --data '{"build_number":"'"${BUILD_NUMBER}"'","job_name":"'"${JOB_NAME}"'","state":"'"${1}"'"}' \
+    "${CICD_SCRIPTS_JOB_POST_HOOK_URL}" &> /dev/null
+fi


### PR DESCRIPTION
Might be used for non-QA jobs later on as well, so kept the name of the post hook URL generic. Might be refactored out and get it's own script later, but for the initial version this feels ok, as it will be used to test some stuff (before doing real changes).