### PR TITLE
[jenkins-library] Webhook Quality of Life improvements

### DIFF
--- a/jenkins-library/src/nl/aerius/jenkinslib/WebhookType.groovy
+++ b/jenkins-library/src/nl/aerius/jenkinslib/WebhookType.groovy
@@ -1,0 +1,6 @@
+package nl.aerius.jenkinslib
+
+enum WebhookType {
+  PRE,
+  POST
+}

--- a/jenkins-library/src/nl/aerius/jenkinslib/util/TestUtil.groovy
+++ b/jenkins-library/src/nl/aerius/jenkinslib/util/TestUtil.groovy
@@ -81,3 +81,68 @@ def static getTestStatusMessage(def currentBuild) {
     }
     return testStatus
 }
+
+def static getTestStatusMap(def currentBuild) {
+    def testStatus = [:]
+    AbstractTestResultAction testResultAction = currentBuild.rawBuild.getAction(AbstractTestResultAction.class)
+    if (testResultAction != null) {
+        def total           = testResultAction.totalCount
+        def failed          = testResultAction.failCount
+        def skipped         = testResultAction.skipCount
+        def passed          = total - failed - skipped
+        def failedCypress   = getFailedCypressCount(testResultAction)
+        def failedK6        = getFailedK6Count(testResultAction)
+        def failedUnittests = failed - failedCypress - failedK6
+
+        def totalPrevious           = null
+        def failedPrevious          = null
+        def skippedPrevious         = null
+        def passedPrevious          = null
+        def failedCypressPrevious   = null
+        def failedK6Previous        = null
+        def failedUnittestsPrevious = null
+
+        def previousResult = testResultAction.getPreviousResult()
+        if (previousResult) {
+            totalPrevious           = previousResult.totalCount
+            failedPrevious          = previousResult.failCount
+            skippedPrevious         = previousResult.skipCount
+            passedPrevious          = totalPrevious - failedPrevious - skippedPrevious
+            failedCypressPrevious   = getFailedCypressCount(previousResult)
+            failedK6Previous        = getFailedK6Count(previousResult)
+            failedUnittestsPrevious = failedPrevious - failedCypressPrevious
+        }
+
+        testStatus << [
+          total           : total,
+          totalPrevious   : totalPrevious,
+          failed          : failed,
+          failedPrevious  : failedPrevious,
+          skipped         : skipped,
+          skippedPrevious : skipped
+        ]
+        if (failedCypress > 0 || (failedCypressPrevious != null && failedCypressPrevious > 0))
+          testStatus << [
+            cypress : [
+              failed         : failedCypress,
+              failedPrevious : failedCypressPrevious
+            ]
+          ]
+        if (failedK6 > 0 || (failedK6Previous != null && failedK6Previous > 0))
+          testStatus << [
+            k6 : [
+              failed         : failedK6,
+              failedPrevious : failedK6Previous
+            ]
+          ]
+        if (failedUnittests > 0 || (failedUnittestsPrevious != null && failedUnittestsPrevious > 0))
+          testStatus << [
+            unittests : [
+              failed         : failedUnittests,
+              failedPrevious : failedUnittestsPrevious
+            ]
+          ]
+    }
+
+    return testStatus
+}

--- a/jenkins-library/vars/cicdPipeline.groovy
+++ b/jenkins-library/vars/cicdPipeline.groovy
@@ -27,6 +27,12 @@ def call(Map config = [:], Closure body) {
             // Set build name
             buildName(sh(script: "${env.CICD_SCRIPTS_DIR}/job/get_build_name.sh", returnStdout: true))
 
+            // Process pre job webhooks and if web hooks are not working, mark job as unstable to signal this (not crashing on purpose).
+            // At this time the webhooks used are just to help make stuff more user friendly, shouldn't be the end of the world if it crashes.
+            catchError(buildResult: 'UNSTABLE', stageResult: 'UNSTABLE') {
+              cicdPipelineProcessPreJobWebhooks(jobIsBuild, jobIsDeploy, jobIsPrChecker, jobIsQA)
+            }
+
             // Keep a map of ENVs we want to wrap the body with. Mostly for convenience and help clean up
             //  the Jenskinsfiles that make use of this pipeline.
             // What we wrap can be found below.

--- a/jenkins-library/vars/cicdPipelineProcessJobWebhooks.groovy
+++ b/jenkins-library/vars/cicdPipelineProcessJobWebhooks.groovy
@@ -1,0 +1,96 @@
+import nl.aerius.jenkinslib.util.HashUtil
+import nl.aerius.jenkinslib.util.StringUtil
+import nl.aerius.jenkinslib.util.TestUtil
+import nl.aerius.jenkinslib.WebhookType
+
+void call(def webhookType, def jobIsBuild, def jobIsDeploy, def jobIsPrChecker, def jobIsQA) {
+  // Add information that we will always supply
+  def payloadMap = [
+    type : webhookType.name(),
+
+    job : [
+      name           : env.JOB_NAME,
+      build_number   : env.BUILD_NUMBER,
+      is_build       : jobIsBuild,
+      is_deploy      : jobIsDeploy,
+      is_prchecker   : jobIsPrChecker,
+      is_qa          : jobIsQA
+    ]
+  ]
+  if (webhookType == WebhookType.POST) {
+    payloadMap.job << [
+      result         : currentBuild.result,
+      crashed_stage  : env.CICD_CRASHED_STAGE,
+      duration       : StringUtil.trimSuffix(currentBuild.durationString, 'and counting')
+    ]
+  }
+
+  // add a deploy block that's only available when it's a deploy job
+  if (jobIsDeploy) {
+    payloadMap << [
+      deploy : [
+        source_job_name          : env.SOURCE_JOB_NAME,
+        source_job_build_number  : env.SOURCE_JOB_BUILD_NUMBER,
+        git_url                  : env.DEPLOY_GIT_URL,
+        git_commit               : env.DEPLOY_GIT_COMMIT,
+        registry_url             : env.AERIUS_REGISTRY_URL,
+        image_tag                : env.DEPLOY_IMAGE_TAG,
+        service_theme            : env.SERVICE_THEME,
+        flags                    : env.FLAGS,
+        mattermost_channel       : env.MATTERMOST_CHANNEL,
+        requested_by_user        : env.REQUESTED_BY_USER,
+        terraform_action         : env.DEPLOY_TERRAFORM_ACTION
+      ]
+    ]
+  }
+
+  // add a QA block that's only available when it's a QA job
+  if (jobIsQA) {
+    payloadMap << [
+      qa : [
+        source_job_name          : env.SOURCE_JOB_NAME,
+        source_job_build_number  : env.SOURCE_JOB_BUILD_NUMBER,
+        git_url                  : env.DEPLOY_GIT_URL,
+        git_commit               : env.DEPLOY_GIT_COMMIT,
+        git_branch_specifier     : env.USE_GIT_BRANCH_SPECIFIER,
+        registry_url             : env.AERIUS_REGISTRY_URL,
+        image_tag                : env.DEPLOY_IMAGE_TAG,
+        flags                    : env.FLAGS,
+        service_theme            : env.SERVICE_THEME,
+        mattermost_channel       : env.MATTERMOST_CHANNEL,
+        requested_by_user        : env.REQUESTED_BY_USER
+      ]
+    ]
+
+    if (webhookType == WebhookType.POST) {
+      payloadMap.qa << [
+        test_results : TestUtil.getTestStatusMap(currentBuild)
+      ]
+    }
+  }
+
+  String payload = new groovy.json.JsonBuilder(payloadMap).toString()
+
+  withCredentials([
+    // Even though the name suggests it can contain multiple webhooks, for now it will only contain a single one.
+    // I do not want to decide what the best separator might be going forward.. Future me's problem.. Life is extra good when ignoring such trivial stuff.
+    string(credentialsId: "CICD_SCRIPTS_PIPELINE_${webhookType.name()}_WEBHOOKS",               variable: 'CICD_SCRIPTS_PIPELINE_WEBHOOKS'),
+    string(credentialsId: "CICD_SCRIPTS_PIPELINE_${webhookType.name()}_WEBHOOKS_CLIENT_SECRET", variable: 'CICD_SCRIPTS_PIPELINE_WEBHOOKS_CLIENT_SECRET')
+  ]) {
+    // Create signature to send together with the request so the webhook can verify we are who we say we are (or someone who is very good at imitating us)
+    String signature = HashUtil.calculateHmac256(payload, CICD_SCRIPTS_PIPELINE_WEBHOOKS_CLIENT_SECRET)
+
+    echo "### [cicdPipeline] - Calling ${webhookType} job webhook"
+    // Call webhook
+    def response = httpRequest(
+      httpMode: 'POST',
+      url: CICD_SCRIPTS_PIPELINE_WEBHOOKS,
+      quiet: true,
+      contentType: 'APPLICATION_JSON',
+      requestBody: payload,
+      customHeaders: [
+        [name: 'X-Hub-Signature-256', value: signature, maskValue: true]
+      ]
+    )
+  }
+}

--- a/jenkins-library/vars/cicdPipelineProcessPreJobWebhooks.groovy
+++ b/jenkins-library/vars/cicdPipelineProcessPreJobWebhooks.groovy
@@ -1,5 +1,5 @@
 import nl.aerius.jenkinslib.WebhookType
 
 void call(def jobIsBuild, def jobIsDeploy, def jobIsPrChecker, def jobIsQA) {
-  cicdPipelineProcessJobWebhooks(WebhookType.POST, jobIsBuild, jobIsDeploy, jobIsPrChecker, jobIsQA)
+  cicdPipelineProcessJobWebhooks(WebhookType.PRE, jobIsBuild, jobIsDeploy, jobIsPrChecker, jobIsQA)
 }


### PR DESCRIPTION
- Support multiple type of webhooks, starting with PRE webhooks next to the already present POST webhooks As the hooks mostly will look the same, try to share code as much as possible.
- Supply duration of the job for POST webhooks
- Supply test results for POST webhooks for QA jobs Some code duplication is present here, but it's rather minimal and I might refactor that after.