### PR TITLE
[jenkins-library] TestUtil: Also provide lastSuccesfulBuildNumber

### DIFF
--- a/jenkins-library/src/nl/aerius/jenkinslib/util/TestUtil.groovy
+++ b/jenkins-library/src/nl/aerius/jenkinslib/util/TestUtil.groovy
@@ -32,6 +32,16 @@ def static getPrettyDiff(def current, def previous) {
     }
 }
 
+def static getLastSuccesfulBuildNumber(def currentBuild) {
+    def lastSucces = currentBuild.previousSuccessfulBuild
+
+    if (lastSucces == null) {
+      return 0
+    }
+
+    return lastSucces.number
+}
+
 def static getTestStatusMessage(def currentBuild) {
     def testStatus = ""
     AbstractTestResultAction testResultAction = currentBuild.rawBuild.getAction(AbstractTestResultAction.class)
@@ -93,6 +103,7 @@ def static getTestStatusMap(def currentBuild) {
         def failedCypress   = getFailedCypressCount(testResultAction)
         def failedK6        = getFailedK6Count(testResultAction)
         def failedUnittests = failed - failedCypress - failedK6
+        def lastSuccesfulBuildNumber = getLastSuccesfulBuildNumber(currentBuild)
 
         def totalPrevious           = null
         def failedPrevious          = null
@@ -119,7 +130,9 @@ def static getTestStatusMap(def currentBuild) {
           failed          : failed,
           failedPrevious  : failedPrevious,
           skipped         : skipped,
-          skippedPrevious : skipped
+          skippedPrevious : skipped,
+
+          lastSuccesfulBuildNumber : lastSuccesfulBuildNumber
         ]
         if (failedCypress > 0 || (failedCypressPrevious != null && failedCypressPrevious > 0))
           testStatus << [


### PR DESCRIPTION
Could be used to determine how long a build has been unstable.